### PR TITLE
Update code for latest occwl version

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,7 +12,7 @@ dependencies:
   - scikit-learn
   - pytorch-lightning
   - xlsxwriter
-  - occwl
+  - occwl=1.0.0
   - jupyter
   - pythreejs
   - tensorboard

--- a/notebooks/brepnet_input_features_similarity_search.ipynb
+++ b/notebooks/brepnet_input_features_similarity_search.ipynb
@@ -152,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "id": "68fd06c7",
    "metadata": {},
    "outputs": [],
@@ -171,7 +171,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 6,
    "id": "88f6c24a",
    "metadata": {
     "scrolled": false
@@ -187,7 +187,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "388371b520d849e5bcbee05f505b5d7d",
+       "model_id": "46ed98da437a4ab59fdf88273da9ef8c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -208,7 +208,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 8,
    "id": "2d6321f8",
    "metadata": {},
    "outputs": [],
@@ -218,7 +218,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 22,
+   "execution_count": 9,
    "id": "72336c63",
    "metadata": {
     "scrolled": false
@@ -240,7 +240,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 23,
+   "execution_count": 10,
    "id": "b5d63d32",
    "metadata": {},
    "outputs": [],
@@ -284,7 +284,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 11,
    "id": "664c4f00",
    "metadata": {},
    "outputs": [
@@ -292,7 +292,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Interval [0.0, 11.654363636270176]\n"
+      "Interval [0.0, 21.304689088927404]\n"
      ]
     }
    ],
@@ -313,7 +313,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 12,
    "id": "5390a62a",
    "metadata": {
     "scrolled": false
@@ -330,7 +330,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c9ea2ff4959643c9b789c6ad8601b140",
+       "model_id": "e6116f9fdf0647c88f044a18bda8c6f0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -345,14 +345,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "19\n",
-      "Close file 52890_dc92327c_3\n"
+      "0\n",
+      "Close file 21492_8bd34fc1_15\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "58a6f6b2f5a3421b86f75f6e2a4cb716",
+       "model_id": "ab77ba55c8a54e38b94bd35e87e60d47",
        "version_major": 2,
        "version_minor": 0
       },
@@ -367,14 +367,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "7\n",
-      "Close file 30274_ca0d10b2_1\n"
+      "9\n",
+      "Close file 56436_2a8fc254_3\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "7a5c1ea406524e2b862a772e182d48df",
+       "model_id": "1539d1dd803c4b5cb8303b648f70176e",
        "version_major": 2,
        "version_minor": 0
       },
@@ -389,14 +389,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "14\n",
-      "Close file 148082_8b644daf_0\n"
+      "10\n",
+      "Close file 37117_89aac9d4_9\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "02fb24f9c41645fd9099f1851b0c7fda",
+       "model_id": "9d0c888ba4de463c9a279d00773dcd9a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -411,14 +411,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "11\n",
-      "Close file 134103_d89213ee_0\n"
+      "20\n",
+      "Close file 44647_d83249a9_0\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f864c150434e49708d2dc4fa8653bbe6",
+       "model_id": "699f75403047422e96ea520910127174",
        "version_major": 2,
        "version_minor": 0
       },
@@ -441,22 +441,6 @@
     "    dists_to_view = min_dists_for_each_face[index]\n",
     "    close_viewer.display_faces_with_heatmap(dists_to_view, interval)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a5ea0cc1",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "fe4bcfd5",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -475,7 +459,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/brepnet_similarity_search.ipynb
+++ b/notebooks/brepnet_similarity_search.ipynb
@@ -82,16 +82,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/lambouj/anaconda3/envs/brepnet/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py:1295: UserWarning: GPU available but not used. Set the gpus flag in your trainer `Trainer(gpus=1)` or script `--gpus=1`.\n",
-      "  \"GPU available but not used. Set the gpus flag in your trainer\"\n",
-      "/home/lambouj/anaconda3/envs/brepnet/lib/python3.7/site-packages/pytorch_lightning/trainer/data_loading.py:106: UserWarning: The dataloader, test dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 36 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
+      "/home/lambouj/anaconda3/envs/brepnet/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py:1585: UserWarning: GPU available but not used. Set the gpus flag in your trainer `Trainer(gpus=1)` or script `--gpus=1`.\n",
+      "  \"GPU available but not used. Set the gpus flag in your trainer `Trainer(gpus=1)` or script `--gpus=1`.\"\n",
+      "/home/lambouj/anaconda3/envs/brepnet/lib/python3.7/site-packages/pytorch_lightning/trainer/data_loading.py:133: UserWarning: The dataloader, test_dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 36 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
       "  f\"The dataloader, {name}, does not have many workers which may be a bottleneck.\"\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "addd3e88662c4f408de611d9b2324c22",
+       "model_id": "b9f8b40a89a24a3fbeb04862392b830a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -110,7 +110,7 @@
       "DATALOADER:0 TEST RESULTS\n",
       "{'test/Chamfer_iou': 0.8418079018592834,\n",
       " 'test/CutEnd_iou': 0.7290322780609131,\n",
-      " 'test/CutSide_iou': 0.810285747051239,\n",
+      " 'test/CutSide_iou': 0.8102856874465942,\n",
       " 'test/ExtrudeEnd_iou': 0.7076271176338196,\n",
       " 'test/ExtrudeSide_iou': 0.8099502325057983,\n",
       " 'test/Fillet_iou': 0.9281437397003174,\n",
@@ -192,7 +192,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 13,
    "id": "13fd9a92",
    "metadata": {
     "scrolled": false
@@ -206,16 +206,9 @@
      ]
     },
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:The `topods_solid` was deprecated since v0.01. It will be removed in v0.03.\n"
-     ]
-    },
-    {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b0e5bc17e824410ea767a3db8a6c93ea",
+       "model_id": "bb42859f955b4f5d9fa2ce6af7898a0b",
        "version_major": 2,
        "version_minor": 0
       },
@@ -236,7 +229,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 14,
    "id": "f1893d90",
    "metadata": {},
    "outputs": [],
@@ -246,7 +239,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 15,
    "id": "a98a6c49",
    "metadata": {},
    "outputs": [],
@@ -261,7 +254,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 16,
    "id": "6a563b97",
    "metadata": {
     "scrolled": false
@@ -309,7 +302,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 17,
    "id": "4c64b822",
    "metadata": {},
    "outputs": [
@@ -317,7 +310,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Interval [0.0, 21.425180436508676]\n"
+      "Interval [0.0, 18.090275079197]\n"
      ]
     }
    ],
@@ -338,7 +331,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 18,
    "id": "893187c8",
    "metadata": {
     "scrolled": false
@@ -355,7 +348,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b4c18162b667417da3fae7a6b2d93543",
+       "model_id": "340dc280c2594ac3b40371d5f8c1d871",
        "version_major": 2,
        "version_minor": 0
       },
@@ -370,14 +363,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "24\n",
-      "Close file 30274_ca0d10b2_1\n"
+      "22\n",
+      "Close file 56436_2a8fc254_3\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "fa6c8517efca4146884095372ea22ac5",
+       "model_id": "a0f1deac6c59496da6b77cd96135e3cd",
        "version_major": 2,
        "version_minor": 0
       },
@@ -392,14 +385,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "0\n",
-      "Close file 52890_dc92327c_3\n"
+      "3\n",
+      "Close file 24051_4852a192_5\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "57fad3aec2544c55b1e1adf79faa5910",
+       "model_id": "e3aae6cd4682480ab67457dbf75994ac",
        "version_major": 2,
        "version_minor": 0
       },
@@ -414,14 +407,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "23\n",
-      "Close file 148082_8b644daf_0\n"
+      "5\n",
+      "Close file 44647_d83249a9_0\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "bf14e029187048a595f17a49692e27ac",
+       "model_id": "c5000d0d66da4b4681bd2ca7eb8a63f6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -436,14 +429,14 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "1\n",
-      "Close file 139656_d270af2a_0\n"
+      "15\n",
+      "Close file 21492_8bd34fc1_15\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "e28c042d0886427085f344ab1fbf4723",
+       "model_id": "0312716185a849048925c23bae453aeb",
        "version_major": 2,
        "version_minor": 0
       },
@@ -466,14 +459,6 @@
     "    dists_to_view = min_dists_for_each_face[index]\n",
     "    close_viewer.display_faces_with_heatmap(dists_to_view, interval)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6c72a8b7",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -492,7 +477,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/find_and_display_segmentation.ipynb
+++ b/notebooks/find_and_display_segmentation.ipynb
@@ -50,7 +50,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 3,
    "id": "cb69622e",
    "metadata": {},
    "outputs": [
@@ -58,8 +58,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "0it [00:00, ?it/s]\n",
-      "GPU available: False, used: False\n",
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [01:51<00:00,  4.46s/it]\n",
+      "GPU available: True, used: False\n",
       "TPU available: False, using: 0 TPU cores\n",
       "IPU available: False, using: 0 IPUs\n"
      ]
@@ -76,14 +76,16 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/home/lambouj/anaconda3/envs/brepnet/lib/python3.7/site-packages/pytorch_lightning/trainer/data_loading.py:106: UserWarning: The dataloader, test dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 36 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
+      "/home/lambouj/anaconda3/envs/brepnet/lib/python3.7/site-packages/pytorch_lightning/trainer/trainer.py:1585: UserWarning: GPU available but not used. Set the gpus flag in your trainer `Trainer(gpus=1)` or script `--gpus=1`.\n",
+      "  \"GPU available but not used. Set the gpus flag in your trainer `Trainer(gpus=1)` or script `--gpus=1`.\"\n",
+      "/home/lambouj/anaconda3/envs/brepnet/lib/python3.7/site-packages/pytorch_lightning/trainer/data_loading.py:133: UserWarning: The dataloader, test_dataloader 0, does not have many workers which may be a bottleneck. Consider increasing the value of the `num_workers` argument` (try 36 which is the number of cpus on this machine) in the `DataLoader` init to improve performance.\n",
       "  f\"The dataloader, {name}, does not have many workers which may be a bottleneck.\"\n"
      ]
     },
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "b49acd5a5d7c4820aba106c82a9d991d",
+       "model_id": "7b33a6645f51441aaafbae72958bd5f5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -102,7 +104,7 @@
       "DATALOADER:0 TEST RESULTS\n",
       "{'test/Chamfer_iou': 0.8418079018592834,\n",
       " 'test/CutEnd_iou': 0.7290322780609131,\n",
-      " 'test/CutSide_iou': 0.810285747051239,\n",
+      " 'test/CutSide_iou': 0.8102856874465942,\n",
       " 'test/ExtrudeEnd_iou': 0.7076271176338196,\n",
       " 'test/ExtrudeSide_iou': 0.8099502325057983,\n",
       " 'test/Fillet_iou': 0.9281437397003174,\n",
@@ -134,7 +136,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 4,
    "id": "c27a8a70",
    "metadata": {},
    "outputs": [
@@ -143,7 +145,7 @@
      "output_type": "stream",
      "text": [
       "We found 25 example files\n",
-      "Viewing example 30419_d55a0a22_2\n"
+      "Viewing example 142473_f37f7cba_0\n"
      ]
     }
    ],
@@ -152,7 +154,7 @@
     "step_file_stems = [ f.stem for f in step_folder.glob(\"*.stp\")]\n",
     "print(f\"We found {len(step_file_stems)} example files\")\n",
     "\n",
-    "example_index = 6\n",
+    "example_index = 0\n",
     "file_stem = step_file_stems[example_index]\n",
     "print(f\"Viewing example {file_stem}\")\n",
     "viewer = JupyterSegmentationViewer(file_stem, step_folder, seg_folder=step_folder, logit_folder=logits_folder)"
@@ -168,14 +170,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 5,
    "id": "407a0d40",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "3bed5667b9c34bf0b4daef8d3428c3ff",
+       "model_id": "5bb6b5b2123b4ebeb3a67dd755799ba0",
        "version_major": 2,
        "version_minor": 0
       },
@@ -201,14 +203,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 6,
    "id": "0d85f794",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0c9ef48d26804470af7add1ca1d7ed45",
+       "model_id": "4c3e9c64b06942e7a7dd5b3f3836a5b6",
        "version_major": 2,
        "version_minor": 0
       },
@@ -234,14 +236,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 7,
    "id": "fb95f0c2",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c33cb7f61c7745d28c79f0e00e1413f9",
+       "model_id": "d6bfd55d377f43f588cc02bebacc7518",
        "version_major": 2,
        "version_minor": 0
       },
@@ -267,14 +269,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 8,
    "id": "d28594ae",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "81c7c323c5104bacaa326f81f1de7b76",
+       "model_id": "fe523e7fd8a54fa69ce2db6ae10ad03f",
        "version_major": 2,
        "version_minor": 0
       },
@@ -289,14 +291,6 @@
    "source": [
     "viewer.view_errors_in_segmentation()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "b2e1206d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -315,7 +309,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/step_viewer_example.ipynb
+++ b/notebooks/step_viewer_example.ipynb
@@ -79,13 +79,6 @@
    "metadata": {},
    "outputs": [
     {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "WARNING:root:The `topods_solid` was deprecated since v0.01. It will be removed in v0.03.\n"
-     ]
-    },
-    {
      "name": "stdout",
      "output_type": "stream",
      "text": [
@@ -117,7 +110,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "0577c349f49c424cabf8404d7d91c693",
+       "model_id": "068375981651401c949f900e6d883337",
        "version_major": 2,
        "version_minor": 0
       },
@@ -150,7 +143,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "c6d6c4efec0d404fabfce2b1dc8c67b6",
+       "model_id": "7631c2b7e0d34610b9de76e9898bd6c9",
        "version_major": 2,
        "version_minor": 0
       },
@@ -165,14 +158,6 @@
    "source": [
     "viewer.view_segmentation()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "f56e5c9b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -191,7 +176,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/notebooks/view_npz_files.ipynb
+++ b/notebooks/view_npz_files.ipynb
@@ -74,9 +74,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "  0%|                                                                                                                                                                                      | 0/25 [00:00<?, ?it/s]WARNING:root:The `topods_edge` was deprecated since v0.01. It will be removed in v0.03.\n",
-      "WARNING:root:The `topods_face` was deprecated since v0.01. It will be removed in v0.03.\n",
-      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [01:44<00:00,  4.18s/it]"
+      "100%|█████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 25/25 [02:51<00:00,  6.85s/it]"
      ]
     },
     {
@@ -101,7 +99,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 4,
    "id": "e405436b",
    "metadata": {},
    "outputs": [
@@ -113,8 +111,7 @@
       "Viewing file\n",
       "npz data /tmp/brepnet_test_working_dir/30419_d55a0a22_2.npz\n",
       "STEP data example_files/step_examples/30419_d55a0a22_2.stp\n",
-      "Loaded 1 solids\n",
-      "Switch back to occwl solid\n"
+      "Loaded 1 solids\n"
      ]
     }
    ],
@@ -151,14 +148,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 21,
+   "execution_count": 18,
    "id": "33dd263f",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "f64f911aa17246999d7117a312c87935",
+       "model_id": "cb662b8ce1814f89b5e74a93a58e4fc5",
        "version_major": 2,
        "version_minor": 0
       },
@@ -179,7 +176,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": 19,
    "id": "15f5dc08",
    "metadata": {},
    "outputs": [
@@ -187,7 +184,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "The faces you selected were [44]\n",
+      "The faces you selected were [101]\n",
       "Shape of face grids (102, 7, 10, 10)\n",
       "Shape of selected face grids (1, 7, 10, 10)\n"
      ]
@@ -224,14 +221,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 7,
    "id": "421ceab5",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "306e98e5b9a24bceb6e01db54aa95cc0",
+       "model_id": "2fc2c2660b514cd0a337271fe23fec6a",
        "version_major": 2,
        "version_minor": 0
       },
@@ -265,14 +262,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 8,
    "id": "05ca45e7",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "72c33f2f80cc4a5c955a37dc32d15491",
+       "model_id": "bfd9bcb67c7e4939955229b3f2a6f664",
        "version_major": 2,
        "version_minor": 0
       },
@@ -320,14 +317,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 20,
    "id": "1822f17a",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "610ffb7a584e46cc9ba098418257c74e",
+       "model_id": "ad121aaa549d40328823f1efd7b5b336",
        "version_major": 2,
        "version_minor": 0
       },
@@ -356,7 +353,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 35,
+   "execution_count": 21,
    "id": "47dac422",
    "metadata": {},
    "outputs": [
@@ -365,10 +362,10 @@
      "output_type": "stream",
      "text": [
       "Found 2 selected faces\n",
-      "Face 0: 39\n",
+      "Face 0: 100\n",
       "Face 1: 36\n",
       "Found edges which shares faces\n",
-      "Coedge index 211\n"
+      "Coedge index 550\n"
      ]
     }
    ],
@@ -435,14 +432,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": 11,
    "id": "d29aa8fa",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "6c180f61bac64793a4870f85bc474494",
+       "model_id": "aa03c1b50311459b970f3e2cc29328d7",
        "version_major": 2,
        "version_minor": 0
       },
@@ -463,7 +460,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 37,
+   "execution_count": 23,
    "id": "065ad546",
    "metadata": {},
    "outputs": [
@@ -472,10 +469,10 @@
      "output_type": "stream",
      "text": [
       "Found 2 selected faces\n",
-      "Face 0: 42\n",
-      "Face 1: 39\n",
+      "Face 0: 48\n",
+      "Face 1: 100\n",
       "Found edges which shares faces\n",
-      "Coedge index 227\n"
+      "Coedge index 258\n"
      ]
     }
    ],
@@ -522,14 +519,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 38,
+   "execution_count": 13,
    "id": "c1450b45",
    "metadata": {},
    "outputs": [
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "4aed16a691b44a29b7e2f38fcdd55c37",
+       "model_id": "54e0f13d721a4e79bf4fb2e0e4f7fa0c",
        "version_major": 2,
        "version_minor": 0
       },
@@ -563,7 +560,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 14,
    "id": "90ca6f7f",
    "metadata": {
     "scrolled": false
@@ -572,7 +569,7 @@
     {
      "data": {
       "application/vnd.jupyter.widget-view+json": {
-       "model_id": "d5fde8283159434e95523358d7c47b30",
+       "model_id": "48cdad7e2f5741a0ad2014bc60ec2866",
        "version_major": 2,
        "version_minor": 0
       },
@@ -630,22 +627,6 @@
     "    display_edge_tangents(edge_tangent_viewer, coedge_grid)\n",
     "edge_tangent_viewer.show()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7fb7365a",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d3bd3805",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -664,7 +645,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.12"
   }
  },
  "nbformat": 4,

--- a/utils/scale_utils.py
+++ b/utils/scale_utils.py
@@ -21,7 +21,7 @@ def scale_solid_to_unit_box(solid):
     if isinstance(solid, Solid):
         return solid.scale_to_unit_box(copy=True)
     solid = Solid(solid, allow_compound=True)
-    solid.scale_to_unit_box(copy=True)
+    solid = solid.scale_to_unit_box(copy=True)
     return solid.topods_shape()
 
 

--- a/utils/scale_utils.py
+++ b/utils/scale_utils.py
@@ -18,47 +18,11 @@ def find_box(solid):
     return bbox
 
 def scale_solid_to_unit_box(solid):
-    is_occwl = False
     if isinstance(solid, Solid):
-        is_occwl = True
-        topods_solid = solid.topods_solid()
-    else:
-        topods_solid = solid
-    bbox = find_box(topods_solid)
-    xmin = 0.0
-    xmax = 0.0
-    ymin = 0.0
-    ymax = 0.0
-    zmin = 0.0
-    zmax = 0.0
-    xmin, ymin, zmin, xmax, ymax, zmax = bbox.Get()
-    dx = xmax - xmin
-    dy = ymax - ymin
-    dz = zmax - zmin
-    longest_length = dx
-    if longest_length < dy:
-        longest_length = dy
-    if longest_length < dz:
-        longest_length = dz
-
-    orig = gp_Pnt(0.0, 0.0, 0.0)
-    center = gp_Pnt((xmin+xmax)/2.0, (ymin+ymax)/2.0, (zmin+zmax)/2.0, )
-    vec_center_to_orig = gp_Vec(center, orig)
-    move_to_center = gp_Trsf()
-    move_to_center.SetTranslation(vec_center_to_orig)
-
-    scale_trsf = gp_Trsf()
-    scale_trsf.SetScale(orig, 2.0/longest_length)
-    trsf_to_apply = scale_trsf.Multiplied(move_to_center)
-    
-    apply_transform = BRepBuilderAPI_Transform(trsf_to_apply)
-    apply_transform.Perform(topods_solid)
-    transformed_solid = apply_transform.ModifiedShape(topods_solid)
-
-    if is_occwl:
-        print("Switch back to occwl solid")
-        return Solid(transformed_solid)
-    return transformed_solid
+        return solid.scale_to_unit_box(copy=True)
+    solid = Solid(solid, allow_compound=True)
+    solid.scale_to_unit_box(copy=True)
+    return solid.topods_shape()
 
 
 

--- a/visualization/jupyter_segmentation_viewer.py
+++ b/visualization/jupyter_segmentation_viewer.py
@@ -75,7 +75,7 @@ class JupyterSegmentationViewer:
         solids = self.load_step()
         assert len(solids) == 1, "Expect only 1 solid"
         self.solid = solids[0]
-        self.entity_mapper = EntityMapper(self.solid.topods_solid())
+        self.entity_mapper = EntityMapper(self.solid.topods_shape())
 
         self.seg_folder = seg_folder
         self.logit_folder = logit_folder
@@ -139,7 +139,7 @@ class JupyterSegmentationViewer:
         renderer = MultiSelectJupyterRenderer()
         renderer.register_select_callback(self.select_face_callback)
         renderer.DisplayShape(
-            self.solid.topods_solid(), 
+            self.solid.topods_shape(), 
             topo_level="Face", 
             render_edges=True, 
             update=True,


### PR DESCRIPTION
# Why?

In  #11 and #12 we see that updates to the occwl library introduced breaking changes which were not spotted in the example notebooks.   Thank you to @[cteqeu](https://github.com/cteqeu) for reporting the issues and @[akashaero](https://github.com/akashaero) for sharing the workaround.

This PR addresses the problems

# What?

- A new version of occwl is released [see here](https://github.com/AutodeskAILab/occwl/releases/tag/v1.0.0).  We now fix the version of occwl to this version to avoid further unexpected breakage.
- In [jupyter_segmentation_viewer.py](visualization/jupyter_segmentation_viewer.py) we remove the calls to the removed functions.
- All the notebooks are rerun and retested.
- Some warnings were firing in [pytorch-lightning](https://github.com/PyTorchLightning/pytorch-lightning/pull/10408).  To ensure that all metrics are computed correctly we pass the number of faces to the logger as the batch size.   Notice that the IoU and accuracy metrics reported in [the paper](https://arxiv.org/abs/2104.00706) are per-face  rather than per solid.
- In [scale_utils.py](utils/scale_utils.py) we make use of the scaling function in occwl rather than re-implementing it here.