### PR TITLE
Fix environment versions

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -6,14 +6,14 @@ channels:
 dependencies:
   - python=3.7
   - pythonocc-core=7.5.1
-  - pytorch
-  - tqdm
-  - igl
-  - scikit-learn
-  - pytorch-lightning
-  - xlsxwriter
+  - pytorch=1.7.1
+  - tqdm=4.64.0
+  - igl=2.2.1
+  - scikit-learn=1.0.2
+  - pytorch-lightning=1.5.10
+  - xlsxwriter=3.0.3
   - occwl=1.0.0
-  - jupyter
-  - pythreejs
-  - tensorboard
+  - jupyter=1.0.0
+  - pythreejs=2.3.0
+  - tensorboard=2.9.0
 


### PR DESCRIPTION
# Why?
See [issues#17](https://github.com/AutodeskAILab/BRepNet/issues/17).  People are having trouble with reproducing results.  Changes to the environment and occwl are causing the BRepNet code to get broken.

# What?
Fix the versions in the `environment.yml` to versions where the code was working.

# Verification
I rebuilt the dataset from the STEP using
```
python -m pipeline.quickstart --dataset_dir /data/FusionGallerySegmentation/s2/s2.0.1 --num_workers 5
```  

I then ran the `reproduce_paper_results.sh` script like this
```
train/reproduce_paper_results.sh /data/FusionGallerySegmentation/s2/s2.0.1
```
I get 
```
DATALOADER:0 TEST RESULTS
{'test/Chamfer_iou': 0.8202725648880005,
 'test/CutEnd_iou': 0.7107243537902832,
 'test/CutSide_iou': 0.7794584631919861,
 'test/ExtrudeEnd_iou': 0.8665122985839844,
 'test/ExtrudeSide_iou': 0.9187023043632507,
 'test/Fillet_iou': 0.973455011844635,
 'test/RevolveEnd_iou': 0.5365853905677795,
 'test/RevolveSide_iou': 0.7514124512672424,
 'test/accuracy': 0.9355261325836182,
 'test/mean_iou': 0.7946403622627258}
```
There were some differences between the STEP and Autodesk Shape Manager versions of the datasets which are documented [here](https://github.com/AutodeskAILab/BRepNet/blob/master/docs/differences_in_open_cascade_pipeline.md).  These numbers are higher than the paper.
